### PR TITLE
Fix .funcignore for remote build and add remoteBuild to azure.yaml

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -6,6 +6,6 @@ metadata:
 services:
   api:
     project: ./src/
-    language: js
+    language: ts
     host: function
     remoteBuild: true

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,3 +8,4 @@ services:
     project: ./src/
     language: js
     host: function
+    remoteBuild: true

--- a/src/.funcignore
+++ b/src/.funcignore
@@ -1,5 +1,4 @@
 *.js.map
-*.ts
 .git*
 .vscode
 __azurite_db*__.json
@@ -7,6 +6,5 @@ __blobstorage__
 __queuestorage__
 local.settings.json
 test
-tsconfig.json
 node_modules
 .DS_Store


### PR DESCRIPTION
## Summary

Fixes the project configuration for remote build when deploying with `azd`.

## Changes

- **azure.yaml**: Added `remoteBuild: true` under the `api` service
- **src/.funcignore**: Fixed contradictory configuration — removed `*.ts` and `tsconfig.json` from ignore list so remote build has access to source code, kept `node_modules` ignored

## Context

When deploying Node.js/TypeScript Azure Functions apps with `azd`, remote build is used. The previous `.funcignore` had a contradictory configuration: it ignored both `*.ts`/`tsconfig.json` (local build pattern) AND `node_modules` (remote build pattern). This meant the remote build would fail because TypeScript source files were excluded. This change removes the `*.ts` and `tsconfig.json` entries so the remote build process can compile the TypeScript code.

## About `remoteBuild: true` in `azure.yaml`

The `remoteBuild: true` flag in `azure.yaml` is being added ahead of support in `azd`. See https://github.com/Azure/azure-dev/pull/6748.

Adding this flag now has no effect on current versions of `azd`, but will be used by new versions that support it. The goal is to explicitly pin the remote build behavior for this project so that it is not affected by potential future changes to the default build behavior in `azd`.