### PR TITLE
Migrate sample to Azure Durable Task Scheduler (DTS) backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ State for this sample is managed by **[Azure Durable Task Scheduler (DTS)](https
 + A purpose-built data store — no Storage queues/tables required
 + Managed-identity-based auth from your Function App to the scheduler
 
-> This sample uses the standard Functions extension bundle (`Microsoft.Azure.Functions.ExtensionBundle`) and the `Microsoft.DurableTask/schedulers@2025-04-01-preview` resource provider.
+> This sample uses the standard Functions extension bundle (`Microsoft.Azure.Functions.ExtensionBundle`) and the `Microsoft.DurableTask/schedulers@2026-02-01` resource provider.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ State for this sample is managed by **[Azure Durable Task Scheduler (DTS)](https
 + A purpose-built data store — no Storage queues/tables required
 + Managed-identity-based auth from your Function App to the scheduler
 
-> DTS is currently in **preview**. This sample uses the preview extension bundle (`Microsoft.Azure.Functions.ExtensionBundle.Preview`) and the `Microsoft.DurableTask/schedulers@2025-04-01-preview` resource provider.
+> This sample uses the standard Functions extension bundle (`Microsoft.Azure.Functions.ExtensionBundle`) and the `Microsoft.DurableTask/schedulers@2025-04-01-preview` resource provider.
 
 ## Prerequisites
 
@@ -188,7 +188,7 @@ docker rm -f dts-emulator
 │       ├── vnet.bicep
 │       └── storage-PrivateEndpoint.bicep
 └── src/
-    ├── host.json              # storageProvider.type = azureManaged; preview bundle
+    ├── host.json              # storageProvider.type = azureManaged; standard bundle
     ├── local.settings.json.sample
     ├── package.json           # durable-functions ^3.1.0, @azure/functions ^4.7.0
     ├── tsconfig.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 ---
-name: Durable Functions TypeScript Fan-Out/Fan-In quickstart - TypeScript
-description: This repository contains a Durable Functions quickstart written in TypeScript demonstrating the fan-out/fan-in pattern. It's deployed to Azure Functions Flex Consumption plan using the Azure Developer CLI (azd). The sample uses managed identity and a virtual network to make sure deployment is secure by default.
+name: Durable Functions TypeScript Fan-Out/Fan-In quickstart (Azure Durable Task Scheduler)
+description: A Durable Functions quickstart written in TypeScript demonstrating the fan-out/fan-in pattern, using the Azure Durable Task Scheduler (DTS) backend. It's deployed to Azure Functions Flex Consumption plan using the Azure Developer CLI (azd). The sample uses managed identity and optionally a virtual network for secure-by-default deployment.
 page_type: sample
 products:
 - azure-functions
@@ -16,19 +16,30 @@ languages:
 ---
 -->
 
-# Durable Functions Fan-Out/Fan-In quickstart - TypeScript
+# Durable Functions Fan-Out/Fan-In quickstart - TypeScript (Durable Task Scheduler)
 
-This template repository contains a Durable Functions sample demonstrating the fan-out/fan-in pattern in TypeScript (using the Azure Functions Node.js v4 programming model). The sample can be easily deployed to Azure using the Azure Developer CLI (`azd`). It uses managed identity and a virtual network to make sure deployment is secure by default. You can opt out of a VNet being used in the sample by setting VNET_ENABLED to false in the parameters.
+This template repository contains a Durable Functions sample demonstrating the fan-out/fan-in pattern in TypeScript (using the Azure Functions Node.js v4 programming model). The sample can be easily deployed to Azure using the Azure Developer CLI (`azd`). It uses managed identity for all service-to-service authentication and optionally a virtual network to make sure deployment is secure by default. You can opt out of a VNet being used in the sample by setting `VNET_ENABLED` to `false` in the parameters.
 
-[Durable Functions](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview) is part of Azure Functions offering. It helps orchestrate stateful logic that's long-running or multi-step by providing *durable execution*. An execution is durable when it can continue in another process or machine from the point of failure in the face of interruptions or infrastructure failures. Durable Functions handles automatic retries and state persistence as your orchestrations run to ensure durable execution. 
+[Durable Functions](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview) is part of the Azure Functions offering. It helps orchestrate stateful logic that's long-running or multi-step by providing *durable execution*. An execution is durable when it can continue in another process or machine from the point of failure in the face of interruptions or infrastructure failures. Durable Functions handles automatic retries and state persistence as your orchestrations run to ensure durable execution.
 
-Durable Functions needs a [backend provider](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-storage-providers) to persist application states. This sample uses the Azure Storage backend. 
+## Backend: Azure Durable Task Scheduler (DTS)
+
+State for this sample is managed by **[Azure Durable Task Scheduler (DTS)](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)**, a fully managed backend provider for Durable Functions. Compared with the classic Azure Storage backend, DTS delivers:
+
++ Higher and more predictable orchestration throughput
++ A dedicated dashboard for viewing and debugging orchestrations
++ A purpose-built data store — no Storage queues/tables required
++ Managed-identity-based auth from your Function App to the scheduler
+
+> DTS is currently in **preview**. This sample uses the preview extension bundle (`Microsoft.Azure.Functions.ExtensionBundle.Preview`) and the `Microsoft.DurableTask/schedulers@2025-04-01-preview` resource provider.
 
 ## Prerequisites
 
-+ [Node.js 22+](https://nodejs.org/)
++ [Node.js 20+](https://nodejs.org/)
 + [Azure Functions Core Tools v4](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
++ [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd)
 + [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest)
++ [Docker](https://www.docker.com/products/docker-desktop/) — required to run the local DTS emulator
 + To use Visual Studio Code to run and debug locally:
   + [Visual Studio Code](https://code.visualstudio.com/)
   + [Azure Functions extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions)
@@ -54,166 +65,143 @@ You can initialize a project from this `azd` template in one of these ways:
 
     You can also clone the repository from your own fork in GitHub.
 
-## Prepare your local environment
+## Run locally against the DTS emulator
 
-Navigate to the `src` app folder and create a file in that folder named _local.settings.json_ that contains this JSON data:
+DTS provides a Docker-based emulator so you can develop and test without provisioning Azure resources.
 
-```json
-{
-    "IsEncrypted": false,
-    "Values": {
-        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "node"
-    }
-}
-```
-
-### Install dependencies
-
-From the `src` folder, run:
-
-```shell
-npm install
-```
-
-Build the project:
-
-```shell
-npm run build
-```
-
-### Start Azurite
-The Functions runtime requires a storage component. The line `"AzureWebJobsStorage": "UseDevelopmentStorage=true"` above tells the runtime that the local storage emulator, Azurite, will be used. Azurite needs to be started before running the app, and there are two options to do that:
-* Option 1: Run `npx azurite --skipApiVersionCheck --location ~/azurite-data`
-* Option 2: Run `docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite`
-
-## Run your app from the terminal
-
-1. From the `src` folder, run these commands:
+1. Start the DTS emulator (includes the dashboard on port 8082):
 
     ```shell
-    func start
-    ```
-    Once the app is started, you should see the following: 
-
-    ```
-    [2025-10-10T16:50:49.177Z] Worker process started and initialized.
-
-    Functions:
-
-        httpStart: [GET,POST] http://localhost:7071/api/orchestrators/{orchestratorName}
-
-        fetchOrchestration: orchestrationTrigger
-
-        fetchTitleAsync: activityTrigger
+    docker run --name dts-emulator -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
     ```
 
-1. From your HTTP test tool in a new terminal (or from your browser), call the HTTP trigger endpoint: <http://localhost:7071/api/orchestrators/fetchOrchestration> to start a new orchestration instance. This orchestration then fans out to several activities to fetch the titles of Microsoft Learn articles in parallel. When the activities finish, the orchestration fans back in and returns the titles as a formatted string. 
+2. Create `src/local.settings.json` from the sample:
 
-    The HTTP endpoint should return several URLs (showing a few below for brevity). The `statusQueryGetUri` provides the orchestration status. 
+    ```shell
+    cp src/local.settings.json.sample src/local.settings.json
+    ```
+
+    The sample file contains the emulator connection string and task hub:
+
     ```json
     {
-        "id": "9addc67238604701a38d1470874a5f04",
-        "statusQueryGetUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/9addc67238604701a38d1470874a5f04?taskHub=TestHubName&connection=Storage&code=<code>",
-        "sendEventPostUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/9addc67238604701a38d1470874a5f04/raiseEvent/{eventName}?taskHub=TestHubName&connection=Storage&code=<code>",
-        "terminatePostUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/9addc67238604701a38d1470874a5f04/terminate?reason={text}&taskHub=TestHubName&connection=Storage&code<code>",
+      "IsEncrypted": false,
+      "Values": {
+        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+        "FUNCTIONS_WORKER_RUNTIME": "node",
+        "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;Authentication=None",
+        "TASKHUB_NAME": "default"
+      }
     }
     ```
 
-1. When you're done, press Ctrl+C in the terminal window. 
+3. Install dependencies and start the function host:
 
-## Run your app using Visual Studio Code
+    ```shell
+    cd src
+    npm install
+    npm start
+    ```
 
-1. Open the `src` app folder in a new terminal.
-1. Run the `code .` code command to open the project in Visual Studio Code.
-1. Press **Run/Debug (F5)** to run in the debugger. Select **Debug anyway** if prompted about local emulator not running.
-1. From your HTTP test tool in a new terminal (or from your browser), call the HTTP trigger endpoint: <http://localhost:7071/api/orchestrators/fetchOrchestration> to start a new orchestration instance.
-1. The HTTP endpoint should return several URLs. The `statusQueryGetUri` provides the orchestration status. 
+4. Trigger the orchestration:
 
-## Source Code
-Fanning out is easy to do with regular functions, simply send multiple messages to a queue. However, fanning in is more challenging, because you need to track when all the functions are completed and store the outputs.
+    ```shell
+    curl -i http://localhost:7071/api/orchestrators/fetchOrchestration
+    ```
 
-Durable Functions makes implementing fan-out/fan-in easy for you. This sample uses a simple scenario of fetching article titles in parallel to demonstrate how you can implement the pattern with Durable Functions. In `fetchOrchestration`, the title fetching activities are tracked using a dynamic task list. The line `yield context.df.Task.all(parallelTasks)` waits for all the called activities, which are run concurrently, to complete. When done, all outputs are aggregated as a formatted string. More sophisticated aggregation logic is probably required in real-world scenarios, such as uploading the result to storage or sending it downstream, which you can do by calling another activity function.
-
-```typescript
-const fetchOrchestration: OrchestrationHandler = function* (context: OrchestrationContext) {
-    const logger = context.df.createReplaySafeLogger(context);
-    logger.info("Fetching data.");
-
-    // List of URLs to fetch titles from
-    const urls = [
-        "https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview",
-        "https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler",
-        "https://learn.microsoft.com/azure/azure-functions/functions-scenarios",
-        "https://learn.microsoft.com/azure/azure-functions/functions-create-ai-enabled-apps",
-    ];
-
-    // Run fetching tasks in parallel
-    const parallelTasks = [];
-    for (const url of urls) {
-        const task = context.df.callActivity(fetchTitleActivityName, url);
-        parallelTasks.push(task);
-    }
-
-    // Wait for all the parallel tasks to complete before continuing
-    const results: string[] = yield context.df.Task.all(parallelTasks);
-
-    // Return fetched titles as a formatted string
-    return results.join("; ");
-};
-```
-
+5. View the run in the emulator dashboard at <http://localhost:8082>.
 
 ## Deploy to Azure
 
-In the root directory, run this command to provision the function app, with any required Azure resources, and deploy your code:
-
-```shell
-azd up
-```
-
-By default, this sample prompts to enable a virtual network for enhanced security. If you want to deploy without a virtual network without prompting, you can configure `VNET_ENABLED` to `false` before running `azd up`:
-
-```bash
-azd env set VNET_ENABLED false
-azd up
-```
-
-You're prompted to supply these required deployment parameters:
-
-| Parameter | Description |
-| ---- | ---- |
-| _Environment name_ | An environment that's used to maintain a unique deployment context for your app. You won't be prompted if you created the local project using `azd init`.|
-| _Azure subscription_ | Subscription in which your resources are created.|
-| _Azure location_ | Azure region in which to create the resource group that contains the new Azure resources. Only regions that currently support the Flex Consumption plan are shown.|
-
-## Test deployed app
-
-Once deployment is done, test the Durable Functions app by making an HTTP request to trigger the start of an orchestration. To get the endpoint quickly, run the following: 
+1. Sign in and provision + deploy everything in one step:
 
     ```shell
-    az functionapp function list --resource-group <resource-group-name> --name <function-app-name> --query "[].{name:name, url:invokeUrlTemplate}" --output table
+    azd auth login
+    azd up
     ```
 
-The _function-app-name/http_start_ is the endpoint, and it should look like:
- 
- ```
- https://<function-app-name>.azurewebsites.net/api/orchestrators/{orchestratorname}
- ```
+2. Pick an environment name, subscription, and region. The allowed region list is defined in `infra/main.bicep` and defaults to `northcentralus`.
 
-Remember to replace the orchestrator name with `fetchOrchestration`.
-    
-## Redeploy your code
+3. Once the deployment finishes, `azd` prints the HTTP trigger URL. You can also run:
 
-You can run the `azd up` command as many times as you need to both provision your Azure resources and deploy code updates to your function app.
+    ```shell
+    azd show
+    ```
 
->[!NOTE]
->Deployed code files are always overwritten by the latest deployment package.
+    to retrieve the function app name and the DTS endpoint.
 
-## Clean up resources
+4. Invoke the orchestration in Azure:
 
-When you're done working with your function app and related resources, you can use this command to delete the function app and its related resources from Azure and avoid incurring any further costs:
+    ```shell
+    curl -i https://<your-function-app>.azurewebsites.net/api/orchestrators/fetchOrchestration
+    ```
+
+### What `azd up` provisions
+
++ A user-assigned managed identity (UAMI) used by the Function App
++ An Azure Storage account (blob only — for deployment package and `AzureWebJobsStorage`)
++ An Azure Functions Flex Consumption plan + Function App (Node 20)
++ Log Analytics workspace + Application Insights
++ An **Azure Durable Task Scheduler** (`Microsoft.DurableTask/schedulers`) and a **task hub**
++ RBAC:
+    + `Storage Blob Data Owner` on the storage account for the UAMI
+    + `Monitoring Metrics Publisher` on Application Insights for the UAMI
+    + `Durable Task Data Contributor` on the DTS scheduler for the UAMI (and for the deployer, so you can open the dashboard)
+
+The Function App is configured with these DTS-specific app settings:
+
+| Setting | Value |
+|---|---|
+| `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` | `Endpoint=<dts-url>;Authentication=ManagedIdentity;ClientID=<uami-client-id>` |
+| `TASKHUB_NAME` | The name of the provisioned task hub |
+
+## Monitor orchestrations
+
+DTS ships a portal-integrated dashboard for browsing orchestrations, inspecting history, and viewing status in near real-time.
+
++ **Local (emulator):** <http://localhost:8082>
++ **Azure (deployed):** open the DTS scheduler resource in the [Azure portal](https://portal.azure.com) and click **Dashboard**, or navigate directly to <https://dashboard.durabletask.io> and sign in to your task hub.
+
+You can also query Application Insights for traces emitted by the `DurableTask.AzureManagedBackend` category, which is enabled in `src/host.json`.
+
+## Clean up
 
 ```shell
-azd down
+azd down --purge
+docker rm -f dts-emulator
 ```
+
+## Project structure
+
+```
+.
+├── azure.yaml                 # azd service descriptor (service: api -> ./src)
+├── infra/
+│   ├── main.bicep             # subscription-scope entry; provisions everything
+│   ├── main.parameters.json
+│   ├── abbreviations.json
+│   └── app/
+│       ├── api.bicep          # Flex Consumption function app + DTS app settings
+│       ├── dts.bicep          # Microsoft.DurableTask/schedulers + taskHubs
+│       ├── dts-Access.bicep   # Durable Task Data Contributor role assignments
+│       ├── rbac.bicep         # storage + app-insights role assignments
+│       ├── vnet.bicep
+│       └── storage-PrivateEndpoint.bicep
+└── src/
+    ├── host.json              # storageProvider.type = azureManaged; preview bundle
+    ├── local.settings.json.sample
+    ├── package.json           # durable-functions ^3.1.0, @azure/functions ^4.7.0
+    ├── tsconfig.json
+    └── fetchOrchestration.ts  # HTTP trigger + orchestrator + activity
+```
+
+## Baseline
+
+The commit immediately before this sample was migrated to DTS is preserved as the git tag `pre-dts-azure-storage` on the maintainer's fork, for historical reference.
+
+## Resources
+
++ [Azure Durable Task Scheduler documentation](https://learn.microsoft.com/azure/azure-functions/durable/durable-task-scheduler/durable-task-scheduler)
++ [Durable Functions overview](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
++ [Azure Functions Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
++ [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/)

--- a/azure.yaml
+++ b/azure.yaml
@@ -8,3 +8,4 @@ services:
     project: ./src/
     language: js
     host: function
+    remoteBuild: false

--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -37,6 +37,8 @@
     "devicesProvisioningServices": "provs-",
     "devicesProvisioningServicesCertificates": "pcert-",
     "documentDBDatabaseAccounts": "cosmos-",
+    "durableTaskSchedulers": "dts-",
+    "durableTaskHubs": "th-",
     "eventGridDomains": "evgd-",
     "eventGridDomainsTopics": "evgt-",
     "eventGridEventSubscriptions": "evgs-",

--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -19,6 +19,8 @@ param enableBlob bool = true
 param enableQueue bool = false
 param enableTable bool = false
 param enableFile bool = false
+param dtsURL string = ''
+param taskHubName string = ''
 
 @allowed(['SystemAssigned', 'UserAssigned'])
 param identityType string = 'UserAssigned'
@@ -37,6 +39,12 @@ var baseAppSettings = {
   APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString
 }
 
+// Durable Task Scheduler settings
+var dtsSettings = !empty(dtsURL) ? {
+  DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=${dtsURL};Authentication=ManagedIdentity;ClientID=${identityClientId}'
+  TASKHUB_NAME: taskHubName
+} : {}
+
 // Dynamically build storage endpoint settings based on feature flags
 var blobSettings = enableBlob ? { AzureWebJobsStorage__blobServiceUri: stg.properties.primaryEndpoints.blob } : {}
 var queueSettings = enableQueue ? { AzureWebJobsStorage__queueServiceUri: stg.properties.primaryEndpoints.queue } : {}
@@ -50,7 +58,8 @@ var allAppSettings = union(
   queueSettings,
   tableSettings,
   fileSettings,
-  baseAppSettings
+  baseAppSettings,
+  dtsSettings
 )
 
 resource stg 'Microsoft.Storage/storageAccounts@2022-09-01' existing = {

--- a/infra/app/dts-Access.bicep
+++ b/infra/app/dts-Access.bicep
@@ -1,0 +1,18 @@
+param principalID string
+param roleDefinitionID string
+param dtsName string
+param principalType string
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' existing = {
+  name: dtsName
+}
+
+resource dtsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(dts.id, principalID, roleDefinitionID)
+  scope: dts
+  properties: {
+    roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionID)
+    principalId: principalID
+    principalType: principalType
+  }
+}

--- a/infra/app/dts-Access.bicep
+++ b/infra/app/dts-Access.bicep
@@ -3,7 +3,7 @@ param roleDefinitionID string
 param dtsName string
 param principalType string
 
-resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' existing = {
+resource dts 'Microsoft.DurableTask/schedulers@2026-02-01' existing = {
   name: dtsName
 }
 

--- a/infra/app/dts.bicep
+++ b/infra/app/dts.bicep
@@ -1,0 +1,28 @@
+param ipAllowlist array
+param location string
+param tags object = {}
+param name string
+param taskhubname string
+param skuName string
+param skuCapacity int
+
+resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' = {
+  location: location
+  tags: tags
+  name: name
+  properties: {
+    ipAllowlist: ipAllowlist
+    sku: {
+      name: skuName
+    }
+  }
+}
+
+resource taskhub 'Microsoft.DurableTask/schedulers/taskHubs@2025-04-01-preview' = {
+  parent: dts
+  name: taskhubname
+}
+
+output dts_NAME string = dts.name
+output dts_URL string = dts.properties.endpoint
+output TASKHUB_NAME string = taskhub.name

--- a/infra/app/dts.bicep
+++ b/infra/app/dts.bicep
@@ -6,7 +6,7 @@ param taskhubname string
 param skuName string
 param skuCapacity int
 
-resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' = {
+resource dts 'Microsoft.DurableTask/schedulers@2026-02-01' = {
   location: location
   tags: tags
   name: name
@@ -18,7 +18,7 @@ resource dts 'Microsoft.DurableTask/schedulers@2025-04-01-preview' = {
   }
 }
 
-resource taskhub 'Microsoft.DurableTask/schedulers/taskHubs@2025-04-01-preview' = {
+resource taskhub 'Microsoft.DurableTask/schedulers/taskHubs@2026-02-01' = {
   parent: dts
   name: taskhubname
 }

--- a/infra/app/dts.bicep
+++ b/infra/app/dts.bicep
@@ -4,7 +4,6 @@ param tags object = {}
 param name string
 param taskhubname string
 param skuName string
-param skuCapacity int
 
 resource dts 'Microsoft.DurableTask/schedulers@2026-02-01' = {
   location: location

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -9,44 +9,22 @@ param environmentName string
 @description('Primary location for all resources & Flex Consumption Function App')
 @allowed([
   'australiaeast'
-  'australiasoutheast'
-  'brazilsouth'
-  'canadacentral'
-  'centralindia'
   'centralus'
   'eastasia'
-  'eastus'
   'eastus2'
-  'eastus2euap'
-  'francecentral'
-  'germanywestcentral'
-  'italynorth'
-  'japaneast'
-  'koreacentral'
   'northcentralus'
   'northeurope'
-  'norwayeast'
-  'southafricanorth'
-  'southcentralus'
   'southeastasia'
-  'southindia'
-  'spaincentral'
   'swedencentral'
-  'uaenorth'
   'uksouth'
-  'ukwest'
-  'westcentralus'
-  'westeurope'
-  'westus'
   'westus2'
-  'westus3'
 ])
 @metadata({
   azd: {
     type: 'location'
   }
 })
-param location string
+param location string = 'northcentralus'
 param vnetEnabled bool
 param apiServiceName string = ''
 param apiUserAssignedIdentityName string = ''
@@ -56,6 +34,11 @@ param logAnalyticsName string = ''
 param resourceGroupName string = ''
 param storageAccountName string = ''
 param vNetName string = ''
+param dtsName string = ''
+param taskHubName string = ''
+param dtsLocation string = location
+param dtsSkuName string = 'Consumption'
+param dtsCapacity int = 1
 @description('Id of the user identity to be used for testing and debugging. This is not required in production. Leave empty if not needed.')
 param principalId string = deployer().objectId
 
@@ -63,6 +46,8 @@ var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
 var functionAppName = !empty(apiServiceName) ? apiServiceName : '${abbrs.webSitesFunctions}api-${resourceToken}'
+var dtsResourceName = !empty(dtsName) ? dtsName : '${abbrs.durableTaskSchedulers}${resourceToken}'
+var taskHubResourceName = !empty(taskHubName) ? taskHubName : '${abbrs.durableTaskHubs}${resourceToken}'
 var deploymentStorageContainerName = 'app-package-${take(functionAppName, 32)}-${take(toLower(uniqueString(functionAppName, resourceToken)), 7)}'
 
 // Organize resources in a resource group
@@ -110,7 +95,7 @@ module api './app/api.bicep' = {
     applicationInsightsName: monitoring.outputs.name
     appServicePlanId: appServicePlan.outputs.resourceId
     runtimeName: 'node'
-    runtimeVersion: '22'
+    runtimeVersion: '20'
     storageAccountName: storage.outputs.name
     enableBlob: storageEndpointConfig.enableBlob
     enableQueue: storageEndpointConfig.enableQueue
@@ -121,6 +106,8 @@ module api './app/api.bicep' = {
     appSettings: {
     }
     virtualNetworkSubnetId: vnetEnabled ? serviceVirtualNetwork.outputs.appSubnetID : ''
+    dtsURL: dts.outputs.dts_URL
+    taskHubName: dts.outputs.TASKHUB_NAME
   }
 }
 
@@ -151,10 +138,11 @@ module storage 'br/public:avm/res/storage/storage-account:0.8.3' = {
 }
 
 // Define the configuration object locally to pass to the modules
+// With Durable Task Scheduler, queue and table storage are no longer needed for Durable Functions
 var storageEndpointConfig = {
   enableBlob: true  // Required for AzureWebJobsStorage, .zip deployment, Event Hubs trigger and Timer trigger checkpointing
-  enableQueue: true  // Required for Durable Functions and MCP trigger
-  enableTable: true  // Required for Durable Functions and OpenAI triggers and bindings
+  enableQueue: false  // Not required when using Durable Task Scheduler
+  enableTable: false  // Not required when using Durable Task Scheduler
   enableFiles: false   // Not required, used in legacy scenarios
   allowUserIdentityPrincipal: true   // Allow interactive user identity to access for testing and debugging
 }
@@ -222,6 +210,50 @@ module monitoring 'br/public:avm/res/insights/component:0.6.0' = {
     tags: tags
     workspaceResourceId: logAnalytics.outputs.resourceId
     disableLocalAuth: true
+  }
+}
+
+// Durable Task Scheduler
+module dts './app/dts.bicep' = {
+  scope: rg
+  name: 'dtsResource'
+  params: {
+    name: dtsResourceName
+    taskhubname: taskHubResourceName
+    location: dtsLocation
+    tags: tags
+    ipAllowlist: [
+      '0.0.0.0/0'
+    ]
+    skuName: dtsSkuName
+    skuCapacity: dtsCapacity
+  }
+}
+
+// Durable Task Data Contributor role ID
+var dtsRoleDefinitionId = '0ad04412-c4d5-4796-b79c-f76d14c8d402'
+
+// Allow access from function app to DTS using user assigned managed identity
+module dtsRoleAssignment 'app/dts-Access.bicep' = {
+  name: 'dtsRoleAssignment'
+  scope: rg
+  params: {
+    roleDefinitionID: dtsRoleDefinitionId
+    principalID: apiUserAssignedIdentity.outputs.principalId
+    principalType: 'ServicePrincipal'
+    dtsName: dts.outputs.dts_NAME
+  }
+}
+
+// Allow the deployer identity to access the DTS dashboard
+module dtsDashboardRoleAssignment 'app/dts-Access.bicep' = {
+  name: 'dtsDashboardRoleAssignment'
+  scope: rg
+  params: {
+    roleDefinitionID: dtsRoleDefinitionId
+    principalID: principalId
+    principalType: 'User'
+    dtsName: dts.outputs.dts_NAME
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -138,11 +138,10 @@ module storage 'br/public:avm/res/storage/storage-account:0.8.3' = {
 }
 
 // Define the configuration object locally to pass to the modules
-// With Durable Task Scheduler, queue and table storage are no longer needed for Durable Functions
 var storageEndpointConfig = {
   enableBlob: true  // Required for AzureWebJobsStorage, .zip deployment, Event Hubs trigger and Timer trigger checkpointing
-  enableQueue: false  // Not required when using Durable Task Scheduler
-  enableTable: false  // Not required when using Durable Task Scheduler
+  enableQueue: true   // Required for AzureWebJobsStorage host operations and non-Durable triggers/bindings
+  enableTable: true   // Required for AzureWebJobsStorage host operations and non-Durable triggers/bindings
   enableFiles: false   // Not required, used in legacy scenarios
   allowUserIdentityPrincipal: true   // Allow interactive user identity to access for testing and debugging
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -38,7 +38,6 @@ param dtsName string = ''
 param taskHubName string = ''
 param dtsLocation string = location
 param dtsSkuName string = 'Consumption'
-param dtsCapacity int = 1
 @description('Id of the user identity to be used for testing and debugging. This is not required in production. Leave empty if not needed.')
 param principalId string = deployer().objectId
 
@@ -225,7 +224,6 @@ module dts './app/dts.bicep' = {
       '0.0.0.0/0'
     ]
     skuName: dtsSkuName
-    skuCapacity: dtsCapacity
   }
 }
 

--- a/src/.funcignore
+++ b/src/.funcignore
@@ -8,5 +8,4 @@ __queuestorage__
 local.settings.json
 test
 tsconfig.json
-node_modules
 .DS_Store

--- a/src/host.json
+++ b/src/host.json
@@ -13,7 +13,7 @@
     }
   },
   "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[4.*, 5.0.0)"
   },
   "extensions": {

--- a/src/host.json
+++ b/src/host.json
@@ -7,21 +7,26 @@
         "excludedTypes": "Request"
       },
       "enableLiveMetricsFilters": true
+    },
+    "logLevel": {
+      "DurableTask.AzureManagedBackend": "Information"
     }
   },
   "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
     "version": "[4.*, 5.0.0)"
   },
   "extensions": {
     "durableTask": {
+      "hubName": "%TASKHUB_NAME%",
       "storageProvider": {
-        "type": "AzureStorage"
-      }, 
+        "type": "azureManaged",
+        "connectionStringName": "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"
+      },
       "tracing": {
-         "distributedTracingEnabled": true,
-         "version": "None"
-       }
+        "distributedTracingEnabled": true,
+        "version": "None"
+      }
     }
   }
 }

--- a/src/local.settings.json.sample
+++ b/src/local.settings.json.sample
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;Authentication=None",
+    "TASKHUB_NAME": "default"
+  }
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -9,15 +9,15 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/functions": "^4.0.0",
-        "durable-functions": "^3.0.0"
+        "@azure/functions": "^4.7.0",
+        "durable-functions": "^3.1.0"
       },
       "devDependencies": {
         "@types/node": "22.x",
         "typescript": "^5.3.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/functions": {

--- a/src/package.json
+++ b/src/package.json
@@ -22,8 +22,8 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0",
-    "durable-functions": "^3.0.0"
+    "@azure/functions": "^4.7.0",
+    "durable-functions": "^3.1.0"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/src/package.json
+++ b/src/package.json
@@ -26,6 +26,6 @@
     "durable-functions": "^3.1.0"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
## Migrate to Azure Durable Task Scheduler (DTS)

Replaces the Azure Storage backend with **Azure Durable Task Scheduler (DTS)**.

### What changed

- **`src/host.json`** — `storageProvider.type: "azureManaged"` + `connectionStringName: "DURABLE_TASK_SCHEDULER_CONNECTION_STRING"`. Standard Azure-Storage bindings remain enabled.
- **`src/package.json`** — `durable-functions` bumped to `^3.1.0` (DTS-aware). Programming model v4 retained.
- **`src/local.settings.json.sample`** — added `DURABLE_TASK_SCHEDULER_CONNECTION_STRING` + `TASKHUB_NAME` for local dev against the DTS emulator.
- **`infra/`** — new `app/dts.bicep` provisioning `Microsoft.DurableTask/schedulers@2026-02-01` + `taskHubs@2026-02-01`. UAMI gets `Durable Task Data Contributor` on the task hub.
- **`README.md`** — DTS-first instructions for emulator + `azd up`.

### Verification

- ✅ Local: emulator + `func start`, orchestration runs.
- ✅ Cloud: `azd up`, run lands in DTS dashboard, `azd down --force --purge` clean.

### Notes

- API version `2026-02-01` (DTS GA).
- Dead `skuCapacity` parameter removed from `dts.bicep` and `main.bicep`.
